### PR TITLE
Package.resolved: fix dependency warning.

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -3,7 +3,7 @@
     "pins": [
       {
         "package": "swift-snapshot-testing",
-        "repositoryURL": "https://github.com/pointfreeco/swift-snapshot-testing.git",
+        "repositoryURL": "https://github.com/Lightricks/swift-snapshot-testing.git",
         "state": {
           "branch": null,
           "revision": "cef5b3f6f11781dd4591bdd1dd0a3d22bd609334",

--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "swift-snapshot-testing",
-                 url: "https://github.com/pointfreeco/swift-snapshot-testing.git",
+                 url: "https://github.com/Lightricks/swift-snapshot-testing.git",
                  from: "1.11.0"),
     ],
     targets: [


### PR DESCRIPTION
Enlight has an explicit dependency with `swift-snapshot-testing` and
an implicit dependency with it from the dependency with
`SnapshotTestingHEIC`, one pointed to pointfree repo and one pointed to
Lightricks repo, this added a constant warning in the Enlight workspace.

This change fixes this warning.
<img width="439" alt="Screenshot 2024-06-26 at 23 01 03" src="https://github.com/Lightricks/SnapshotTestingHEIC/assets/51407572/5961dbd6-e5e0-4653-910c-c06b42c9597b">

